### PR TITLE
Update QtWidgetsApplication.pro

### DIFF
--- a/QtWidgetsApplication/QtWidgetsApplication.pro
+++ b/QtWidgetsApplication/QtWidgetsApplication.pro
@@ -31,7 +31,7 @@ HEADERS  += mainwindow.h
 FORMS    += mainwindow.ui
 
 target.path = $$PREFIX/bin
-icon.path = $$PREFIX/share/icons/hicolor/512x512
+icon.path = $$PREFIX/share/icons/hicolor/512x512/apps
 icon.files = QtWidgetsApplication.png
 
 desktop_entry.path = $$PREFIX/share/applications


### PR DESCRIPTION
Default icons should go to `/usr/share/icons/hicolor/512x512/apps` according to <https://developer.gnome.org/integration-guide/stable/icons.html.en>